### PR TITLE
Hooking the search field up

### DIFF
--- a/coffee/index.coffee
+++ b/coffee/index.coffee
@@ -44,3 +44,9 @@ filter = (term) ->
     comparisons.classList.add 'empty'
   else
     comparisons.classList.remove 'empty'
+
+document.addEventListener 'DOMContentLoaded', ->
+  search = document.querySelector('input[type="search"]')
+
+  search.addEventListener 'input', ->
+    filter search.value

--- a/js/index.js
+++ b/js/index.js
@@ -72,4 +72,12 @@
     }
   };
 
+  document.addEventListener('DOMContentLoaded', function() {
+    var search;
+    search = document.querySelector('input[type="search"]');
+    return search.addEventListener('input', function() {
+      return filter(search.value);
+    });
+  });
+
 }).call(this);


### PR DESCRIPTION
Noticed it wasn't hooked up. Not really sure if it's really needed since it mimics `CMD+F` although this can always be scoped to specific element types (ie: headings).
