### PR TITLE
Minor adjustments for display on iPhone / iOS Safari

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -165,8 +165,13 @@ html.old-ie .old-ie-message {
 }
 .comparison h3 {
   text-align: center;
-  font-size: 2em;
+  font-size: 1.8em;
   font-weight: normal;
+}
+@media (min-width: 768px) {
+  .comparison h3 {
+    font-size: 2em;
+  }
 }
 .comparison h3 a {
   position: relative;
@@ -311,13 +316,19 @@ section .comparison {
   padding-bottom: -40px;
 }
 section h2 {
-  font-size: 3em;
+  font-size: 2.2em;
   font-weight: 100;
-  letter-spacing: 0.3em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
   color: #888;
   text-align: center;
   margin: 0;
+}
+@media (min-width: 768px) {
+  section h2 {
+    font-size: 3em;
+    letter-spacing: 0.3em;
+  }
 }
 input[type='range'] {
   -webkit-appearance: none !important;

--- a/css/index.css
+++ b/css/index.css
@@ -208,6 +208,10 @@ header.search:after {
 header.search:after {
   clear: both;
 }
+input {
+  border-radius: 0;
+  -webkit-appearance: none;
+}
 header.search input[type="search"] {
   height: 3em;
   border: 0;

--- a/css/index.css
+++ b/css/index.css
@@ -272,7 +272,6 @@ header.search .field .slider {
   text-align: center;
 }
 .resources-block h4 {
-  font-size: 1.1em;
   display: inline-block;
   font-weight: 200;
   color: #666;


### PR DESCRIPTION
Addressing an issue pointed out via Twitter

https://twitter.com/chousmith/status/786009559492022272

wherein the section H2 headers were so large and spaced out that they only partially appeared on iPhone (window width = 320px)

Made the section H2 smaller & less spaced for screen width < 768px, and added media query to restore the previous large size and spacing for screen size >= 768px.

The slightly smaller H2 (2.2em) was then quite close to the .comparison H3 (2em), so likewise decrease the initial size of H3 to be between the H4 and the H2 on mobile screen width < 768px, while keeping sizing the same on width >= 768px.

And lastly, added a quick rule to remove the rounded corners of the Search box in the header on iOS Safari as well, to match other browsers?

This updated version can be previewed at https://chousmith.github.io/YouMightNotNeedJS/

as compared to the original issue which looked like this

![Text Cutoff](https://pbs.twimg.com/media/Cuh3hmHVUAAJSDK.jpg)
