### PR TITLE
use tab indentation in scroll_indicator.scss

### DIFF
--- a/comparisons/interactions/scroll_indicator/scss.scss
+++ b/comparisons/interactions/scroll_indicator/scss.scss
@@ -1,7 +1,7 @@
 body {	
 	background: linear-gradient(to right top, 
-      $scroller-color 50%, 
-      $scroller-background 50%);
+	$scroller-color 50%, 
+	$scroller-background 50%);
 	background-size: 100% calc(100% - 100vh + #{$scroller-height}); 
 	background-repeat: no-repeat;
 }


### PR DESCRIPTION
I think there are more places that have 4 spaces / 1 tab. What do you prefer?
