### PR TITLE
Modal dialog accessibility

### DIFF
--- a/comparisons/components/modal/html.html
+++ b/comparisons/components/modal/html.html
@@ -2,6 +2,7 @@
 	Click Me
 </a>
 
-<dialog class="modal" id="modalDialog1" tabindex="-1">
+<dialog class="modal" id="modalDialog1"
+		tabindex="-1" role="dialog">
   <p>Hello Beautiful!</p>
 </dialog>

--- a/comparisons/components/modal/html.html
+++ b/comparisons/components/modal/html.html
@@ -1,5 +1,7 @@
-<button>Click Me</button>
+<a class="modalTrigger" href="#modalDialog1">
+	Click Me
+</a>
 
-<div class="modal">
+<dialog class="modal" id="modalDialog1" tabindex="-1">
   <p>Hello Beautiful!</p>
-</div>
+</dialog>

--- a/comparisons/components/modal/html.html
+++ b/comparisons/components/modal/html.html
@@ -1,8 +1,14 @@
-<a class="modalTrigger" href="#modalDialog1">
-	Click Me
+<a class="modalTrigger" id="modalTrigger"
+   href="#modalDialog1">
+	Open dialog
 </a>
 
 <dialog class="modal" id="modalDialog1"
 		tabindex="-1" role="dialog">
-  <p>Hello Beautiful!</p>
+  <div>
+	  <a href="#modalTrigger" aria-label="Close">
+	  	&times;
+	  </a>
+	  <p>Hello Beautiful!</p>
+  </div>
 </dialog>

--- a/comparisons/components/modal/scss.scss
+++ b/comparisons/components/modal/scss.scss
@@ -1,16 +1,14 @@
-// Modal is visually hidden until focused.
-// This only sort-of works: you can't close
-// the dialog with the escape key, and it can't
-// contain anything interactive for 2 reasons: 
-// you wouldn't be able to tab without blurring 
-// the dialog, and they'd be focusable when 
-// the dialog is closed (a poor keyboard experience).
-.modal {  
+// Modal is hidden until it matches an anchor
+// target. This only sort-of works, as you can't close
+// it with the escape key or trap focus inside of it.
+.modal {
   opacity: 0;
+  visibility: hidden;
 }
 
-// modal fades in when button 
-// is in focus (i.e. clicked on)
-.modal:focus {
+// modal fades in when it matches
+// an anchor link (i.e. clicked on)
+#modalDialog:target {
   opacity: 1;
+  visibility: hidden;
 }

--- a/comparisons/components/modal/scss.scss
+++ b/comparisons/components/modal/scss.scss
@@ -1,13 +1,16 @@
-// modal is invisible until
-// sibling is focused
+// Modal is visually hidden until focused.
+// This only sort-of works: you can't close
+// the dialog with the escape key, and it can't
+// contain anything interactive for 2 reasons: 
+// you wouldn't be able to tab without blurring 
+// the dialog, and they'd be focusable when 
+// the dialog is closed (a poor keyboard experience).
 .modal {  
   opacity: 0;
-  visibility: hidden;
 }
 
 // modal fades in when button 
 // is in focus (i.e. clicked on)
-button:focus + .modal {
+.modal:focus {
   opacity: 1;
-  visibility: visible;
 }

--- a/index.html
+++ b/index.html
@@ -159,29 +159,33 @@
               <div data-code="html" class="code html">
                 <h4>HTML</h4>
                 <div data-lang="markup" class="code-block language-markup">
-                  <pre><code>&lt;button&gt;Click Me&lt;/button&gt;
+                  <pre><code>&lt;a class=&quot;modalTrigger&quot; href=&quot;#modalDialog1&quot;&gt;
+	Click Me
+&lt;/a&gt;
 
-&lt;div class=&quot;modal&quot;&gt;
+&lt;dialog class=&quot;modal&quot; id=&quot;modalDialog1&quot; tabindex=&quot;-1&quot;&gt;
   &lt;p&gt;Hello Beautiful!&lt;/p&gt;
-&lt;/div&gt;
-</code></pre>
+&lt;/dialog&gt;</code></pre>
                 </div>
               </div>
               <div data-code="scss" class="code scss">
                 <h4>SCSS</h4>
                 <div data-lang="scss" class="code-block language-scss">
-                  <pre><code>// modal is invisible until
-// sibling is focused
+                  <pre><code>// Modal is visually hidden until focused.
+// This only sort-of works: you can't close
+// the dialog with the escape key, and it can't
+// contain anything interactive for 2 reasons: 
+// you wouldn't be able to tab without blurring 
+// the dialog, and they'd be focusable when 
+// the dialog is closed (a poor keyboard experience).
 .modal {  
   opacity: 0;
-  visibility: hidden;
 }
 
 // modal fades in when button 
 // is in focus (i.e. clicked on)
-button:focus + .modal {
+.modal:focus {
   opacity: 1;
-  visibility: visible;
 }</code></pre>
                 </div>
               </div>

--- a/index.html
+++ b/index.html
@@ -163,7 +163,8 @@
 	Click Me
 &lt;/a&gt;
 
-&lt;dialog class=&quot;modal&quot; id=&quot;modalDialog1&quot; tabindex=&quot;-1&quot;&gt;
+&lt;dialog class=&quot;modal&quot; id=&quot;modalDialog1&quot; 
+		tabindex=&quot;-1&quot; role=&quot;dialog&quot;&gt;
   &lt;p&gt;Hello Beautiful!&lt;/p&gt;
 &lt;/dialog&gt;</code></pre>
                 </div>

--- a/index.html
+++ b/index.html
@@ -159,34 +159,39 @@
               <div data-code="html" class="code html">
                 <h4>HTML</h4>
                 <div data-lang="markup" class="code-block language-markup">
-                  <pre><code>&lt;a class=&quot;modalTrigger&quot; href=&quot;#modalDialog1&quot;&gt;
-	Click Me
+                  <pre><code>&lt;a class=&quot;modalTrigger&quot; id=&quot;modalTrigger&quot;
+   href=&quot;#modalDialog1&quot;&gt;
+	Open dialog
 &lt;/a&gt;
 
-&lt;dialog class=&quot;modal&quot; id=&quot;modalDialog1&quot; 
+&lt;dialog class=&quot;modal&quot; id=&quot;modalDialog1&quot;
 		tabindex=&quot;-1&quot; role=&quot;dialog&quot;&gt;
-  &lt;p&gt;Hello Beautiful!&lt;/p&gt;
-&lt;/dialog&gt;</code></pre>
+    &lt;a href=&quot;#modalTrigger&quot; aria-label=&quot;Close&quot;&gt;
+      &amp;times;
+    &lt;/a&gt;
+  &lt;div&gt;
+	  &lt;p&gt;Hello Beautiful!&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/dialog&gt;
+</code></pre>
                 </div>
               </div>
               <div data-code="scss" class="code scss">
                 <h4>SCSS</h4>
                 <div data-lang="scss" class="code-block language-scss">
-                  <pre><code>// Modal is visually hidden until focused.
-// This only sort-of works: you can't close
-// the dialog with the escape key, and it can't
-// contain anything interactive for 2 reasons: 
-// you wouldn't be able to tab without blurring 
-// the dialog, and they'd be focusable when 
-// the dialog is closed (a poor keyboard experience).
-.modal {  
+                  <pre><code>// Modal is hidden until it matches an anchor
+// target. This only sort-of works, as you can't close
+// it with the escape key or trap focus inside of it.
+.modal {
   opacity: 0;
+  visibility: hidden;
 }
 
-// modal fades in when button 
-// is in focus (i.e. clicked on)
-.modal:focus {
+// modal fades in when it matches
+// an anchor link (i.e. clicked on)
+#modalDialog:target {
   opacity: 1;
+  visibility: hidden;
 }</code></pre>
                 </div>
               </div>


### PR DESCRIPTION
So my first attempt at a component accessibility improvement is for the modal dialog. I wrote a comment warning about the limitations, since it is not a real-world solution. But I think it captures the spirit of the project by showing something cool with CSS and focus management. I changed the DIV to a native dialog element but the API for opening it requires JavaScript. Waah waah....

My first example showed the dialog by focusing on it with an internal link, but it was more limited. The latest version uses `:target` so you can actually tab to the child items inside the dialog. But it doesn't trap focus, so it's still limited. If HTML `inert` was a thing, you could trap focus more easily. But it would still require JS to toggle it on the background content. 

Note: it still needs JS to bind the escape key to close the dialog, an important convention for interactive overlays.

Here's the Codepen: http://codepen.io/marcysutton/pen/mAKrxb

If you're curious about hiding things with CSS and how they impact the keyboard, this video might come in handy: https://egghead.io/lessons/html-5-visible-vs-hidden
