### PR TITLE
Add new component: show/hide truncated text

### DIFF
--- a/comparisons/components/show_hide_truncated_text/caniuse.txt
+++ b/comparisons/components/show_hide_truncated_text/caniuse.txt
@@ -1,0 +1,3 @@
+Target: http://caniuse.com/#feat=css-sel3
+line-camp: http://caniuse.com/#search=line-clamp
+Flex: http://caniuse.com/#search=flex

--- a/comparisons/components/show_hide_truncated_text/codepen.html
+++ b/comparisons/components/show_hide_truncated_text/codepen.html
@@ -1,0 +1,1 @@
+<p data-height="265" data-theme-id="light" data-slug-hash="WGBzZa" data-default-tab="html,result" data-user="srekoble" data-embed-version="2" class="codepen">See the Pen <a href="http://codepen.io/srekoble/pen/WGBzZa/">show/hide text with row truncate</a> by Vangel Tzo (<a href="http://codepen.io/srekoble">@srekoble</a>) on <a href="http://codepen.io">CodePen</a>.</p>

--- a/comparisons/components/show_hide_truncated_text/html.html
+++ b/comparisons/components/show_hide_truncated_text/html.html
@@ -1,0 +1,7 @@
+<div class="show-hide-text">
+  <a  id="show-more" class="show-less" href="#show-less">Show less</a>
+  <a  id="show-less" class="show-more" href="#show-more">Show more</a>
+  <p>
+    Lorem Ipsum is simply dummy text of  the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+  </p>
+</div>

--- a/comparisons/components/show_hide_truncated_text/resources.txt
+++ b/comparisons/components/show_hide_truncated_text/resources.txt
@@ -1,0 +1,1 @@
+Vangel Tzo show/hide text: http://codepen.io/srekoble/pen/WGBzZa

--- a/comparisons/components/show_hide_truncated_text/scss.scss
+++ b/comparisons/components/show_hide_truncated_text/scss.scss
@@ -1,0 +1,35 @@
+@mixin truncate($rows) {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: $rows;
+  -webkit-box-orient: vertical;
+}
+
+.show-hide-text {
+  display: flex;
+  flex-wrap: wrap;
+
+  a {
+    order: 2;
+  }
+
+  p {
+    @include truncate(3);
+  }
+}
+
+.show-less {
+  display: none;
+
+  &:target {
+    display: block;
+
+    ~ p {
+      display: block;
+    }
+
+    + a {
+      display: none;
+    }
+  }
+}

--- a/comparisons/components/show_hide_truncated_text/scss.scss
+++ b/comparisons/components/show_hide_truncated_text/scss.scss
@@ -1,20 +1,59 @@
-@mixin truncate($rows) {
+@mixin row-truncate($rows, $line-height, $background: '') {
+  position: relative;
   overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: $rows;
-  -webkit-box-orient: vertical;
+  max-height: $line-height * $rows;
+  line-height: $line-height;
+
+  &:after {
+    content: "";
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    width: 100px;
+    height: $line-height;
+
+    @if $background != '' {
+      background: -moz-linear-gradient(left, rgba($background, 0) 0%, rgba($background, 1) 100%);
+      background: -webkit-gradient(linear, left top, right top, color-stop(0%, rgba($background, 0)), color-stop(100%, rgba($background, 1)));
+      background: -webkit-linear-gradient(left, rgba($background, 0) 0%,rgba($background, 1) 100%);
+      background: -o-linear-gradient(left, rgba($background, 0) 0%, rgba($background, 1) 100%);
+      background: -ms-linear-gradient(left, rgba($background, 0) 0%, rgba($background, 1) 100%);
+      background: linear-gradient(to right, rgba($background, 0) 0%, rgba($background, 1) 100%);
+    }
+  }
+
+  // If supports line-clamp then add an ellipsis overflow and hide the gradient
+  // This will work in Chrome and Opera, otherwise a gradient will gradually hide the text.
+
+  @supports (-webkit-line-clamp: $rows) {
+    display: -webkit-box;
+    -webkit-line-clamp: $rows;
+    -webkit-box-orient: vertical;
+
+    &:after {
+      display: none;
+    }
+  }
 }
 
 .show-hide-text {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
   display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
   flex-wrap: wrap;
 
   a {
+    -webkit-box-ordinal-group: 3;
+    -webkit-order: 2;
+    -ms-flex-order: 2;
     order: 2;
   }
 
   p {
-    @include truncate(3);
+    @include truncate(3, 20px, #fff); // rows, line-height, gradient fallback
   }
 }
 
@@ -26,6 +65,11 @@
 
     ~ p {
       display: block;
+      max-height: 100%;
+
+      &:after {
+        display: none;
+      }
     }
 
     + a {


### PR DESCRIPTION
A pure css component with :target, row truncation via line-clamp and flex
in order to create together a fully functional show/hide toggle for
truncated text(in specific rows that we assign with the help of a mixin).

Demo: http://codepen.io/srekoble/pen/WGBzZa

Cheers!
